### PR TITLE
new test allocating a large vec + mac-os support

### DIFF
--- a/src/diskalloc.rs
+++ b/src/diskalloc.rs
@@ -53,12 +53,24 @@ impl AtomDiskAlloc {
     }
 
     pub fn on_file(file: File) -> Result<Self, std::io::Error> {
+        #[cfg(target_os = "linux")]
         let addr = unsafe {
             libc::mmap(
                 std::ptr::null_mut(),
                 STORAGE as libc::size_t,
-                libc::PROT_WRITE,
+                libc::PROT_WRITE | libc::PROT_READ,
                 libc::MAP_SHARED_VALIDATE,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        #[cfg(target_os = "macos")]
+        let addr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                STORAGE as libc::size_t,
+                libc::PROT_WRITE | libc::PROT_READ,
+                libc::MAP_SHARED,
                 file.as_raw_fd(),
                 0,
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![feature(allocator_api)]
-#![feature(pointer_byte_offsets)]
 mod diskalloc;
 
 pub use diskalloc::DiskAlloc;

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -1,6 +1,5 @@
 #![feature(allocator_api)]
 
-
 use diskallocator::{self, DiskAlloc};
 use rand::Rng;
 
@@ -85,4 +84,24 @@ fn multi_allocs() {
         .map(|_| DiskAlloc::new().unwrap())
         .collect::<Vec<DiskAlloc>>();
     assert_eq!(allocator_collection.len(), count);
+}
+
+#[test]
+fn large_memory_vec() {
+    // creates a vector that will take 60g of RAM.
+    let mut v = Vec::with_capacity_in(60_000_000_000, DiskAlloc::new().unwrap());
+    for byte in 0_i64..60_000_000_000 {
+        if byte % 1_000_000_000 == 0 {
+            println!("{byte}");
+        }
+
+        v.push(byte);
+    }
+    for byte in 0_i64..60_000_000_000 {
+        if byte % 1_000_000_000 == 0 {
+            println!("{byte}");
+        }
+
+        assert_eq!(v[byte as usize], byte);
+    }
 }


### PR DESCRIPTION
Hi,

thanks for your amazing library. I had to get this to work on macos allocating some large vecs. Simple cfg for the macos target + a large allocation test. Adding some benchmarks.

```
/usr/bin/time -l cargo test -- --show-output --nocapture large_memory_vec

     2511.70 real      1314.42 user       270.96 sys
         26918191104  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               49154  page reclaims
            58591628  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   4  signals received
              148620  voluntary context switches
            17785392  involuntary context switches
           401968575  instructions retired
           143246395  cycles elapsed
            10683776  peak memory footprint
```
